### PR TITLE
Allow specifying optional parameters for lookup call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in yandex-translator.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: .
+  specs:
+    yandex-dictionary (0.2.0)
+      httparty
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    hashdiff (0.3.1)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
+    multi_xml (0.6.0)
+    public_suffix (2.0.4)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    webmock (2.3.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (~> 3.1)
+  webmock
+  yandex-dictionary!
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ To get dictionary entry about word(in json) use lookup method:
   Yandex::Dictionary.lookup 'Amnesty', 'en', 'en'
 ```
 
+Optional parameters can be specified such:
+
+```ruby
+  Yandex::Dictionary.lookup 'Amnesty', 'en', 'en', flags: %(family morpho), ui: 'ru'
+```
+
+(for more details see the [official method definition](https://tech.yandex.com/dictionary/doc/dg/reference/lookup-docpage/))
+
 ## Contributing
 
 1. Fork it

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new('spec')

--- a/lib/yandex_dictionary.rb
+++ b/lib/yandex_dictionary.rb
@@ -12,13 +12,29 @@ module Yandex::Dictionary
 
   # List of translation directions.
   def get_langs
+    langs
+  end
+
+  def langs
     visit('/getLangs').to_a
   end
 
   # Search word or phrase. Return dictionary entry.
-  def lookup(text, *lang)
-    options = { text: text, lang: lang.join('-') }
+  def lookup(text, from_lang, to_lang, params = {})
+    options = { text: text, lang: [from_lang, to_lang].join('-') }
+    options[:flags] = determine_flags(params[:flags]) if params.key?(:flags)
+    options[:ui] = params[:ui] if params.key?(:ui)
     visit('/lookup', options)['def']
+  end
+
+  protected
+
+  def determine_flags(flags)
+    flag = 0
+    flag += 1 if flags.include?(:family)
+    flag += 4 if flags.include?(:morpho)
+    flag += 8 if flags.include?(:pos)
+    flag
   end
 
   def visit(address, options = {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+require 'yandex_dictionary'
+require 'webmock/rspec'
+include WebMock
+
+RSpec.configure do |config|
+end

--- a/spec/yandex/dictionary_spec.rb
+++ b/spec/yandex/dictionary_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Yandex::Dictionary do
+  let(:api_key) { 'secret' }
+
+  before(:each) { Yandex::Dictionary.api_key = api_key }
+
+  let(:base_url) do
+    'https://dictionary.yandex.net/api/v1/dicservice.json'
+  end
+  let(:request_url) { "#{base_url}/#{request_action}?#{request_body}" }
+  let(:response_body) { '{}' }
+
+  before(:each) do
+    stub_request(:get, request_url).to_return(
+      body: response_body,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+  end
+
+  describe '#langs' do
+    let(:request_action) { 'getLangs' }
+
+    describe 'sends the correct api key and parameters' do
+      let(:request_body) { "key=#{api_key}" }
+
+      it do
+        Yandex::Dictionary.langs
+      end
+    end
+  end
+
+  describe '#lookup' do
+    let(:request_action) { 'lookup' }
+
+    describe 'sends the correct api key and parameters' do
+      let(:request_body) { "key=#{api_key}&lang=en-ru&text=Car" }
+
+      it do
+        Yandex::Dictionary.lookup('Car', 'en', 'ru')
+      end
+    end
+
+    describe 'sends the correct flags if specified' do
+      describe 'morpho' do
+        let(:request_body) { "flags=4&key=#{api_key}&lang=en-ru&text=Car" }
+
+        it do
+          Yandex::Dictionary.lookup('Car', 'en', 'ru', flags: %i(morpho))
+        end
+      end
+
+      describe 'morpho and family' do
+        let(:request_body) { "flags=5&key=#{api_key}&lang=en-ru&text=Car" }
+
+        it do
+          Yandex::Dictionary.lookup('Car', 'en', 'ru', flags: %i(morpho family))
+        end
+      end
+    end
+
+    describe 'sends the ui language if specified' do
+      let(:request_body) { "key=#{api_key}&lang=en-ru&text=Car&ui=ru" }
+
+      it do
+        Yandex::Dictionary.lookup('Car', 'en', 'ru', ui: 'ru')
+      end
+    end
+  end
+end

--- a/yandex_dictionary.gemspec
+++ b/yandex_dictionary.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'httparty'
+  s.add_development_dependency 'rspec', '~> 3.1'
+  s.add_development_dependency 'webmock'
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Hello Sergey,

I am currently working on a little side project where I wanted to use Yandex' Dictionary API and I found your little gem very useful for that. However, I found that I actually needed some of the optional flags that the API allows for, but which your gem does not accommodate for. I have therefore added them myself and expanded your gem with some test coverage to guarantee it still works. Here are the changes in this pull request:

  - Removes the ability to specify any other number than two languages in lookup call. This would be illegal anyway according to the API documentation
  - Adds the ability to optionally supply `flags` and `ui` parameters to a lookup call. Flags expects  an array of flags which are specified as symbols.
  - I added a `langs` method that is synonym with `get_langs` to make it more similar in usage with the [yandex-translator](https://github.com/aegorov/yandex-translator) gem and because rubycop was bugging me about the name
- Adding rspec tests to the existing methods to cover potential regression issues

I would be happy to see the changes merged if you agree with them.

Еще раз благодарю вас и желаю вам счастливого Нового года.

-- Patrick